### PR TITLE
Fix "Open this page in mpv" feature

### DIFF
--- a/extension/Chrome/background.js
+++ b/extension/Chrome/background.js
@@ -2,7 +2,7 @@ import { getOptions, openInMPV, updateBrowserAction } from "./common.js";
 
 updateBrowserAction();
 
-[["page", "url"], ["link", "linkUrl"], ["video", "srcUrl"], ["audio", "srcUrl"]].forEach(([item, linkType]) => {
+[["page", "pageUrl"], ["link", "linkUrl"], ["video", "srcUrl"], ["audio", "srcUrl"]].forEach(([item, linkType]) => {
     chrome.contextMenus.create({
         title: `Open this ${item} in mpv`,
         id: `open${item}inmpv`,


### PR DESCRIPTION
"Open this page in mpv" feature is not working due to the wrong key name in this line. 
https://github.com/Baldomo/open-in-mpv/blob/74987a4ba991c9cf4c3219b3804e1dd97e6e337a/extension/Chrome/background.js#L5

According to the documentation, "linkType" in the first array item should be "pageUrl" instead of "url".
https://developer.chrome.com/docs/extensions/reference/contextMenus/##property-OnClickData-pageUrl

This PR will fix this issue.
I tested this on Firefox and Chromium on Linux.