### PR TITLE
Set default supported schemas when no config file is provided

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,14 +48,15 @@ var defaultSupportedSchemas = []string{
 var defaultConfig = Config{
 	Players: map[string]Player{
 		"mpv": {
-			Name:          "mpv",
-			Executable:    "mpv",
-			Fullscreen:    "--fs",
-			Pip:           `--ontop --no-border --autofit=384x216 --geometry=98%:98%`,
-			Enqueue:       "",
-			NewWindow:     "",
-			NeedsIpc:      true,
-			FlagOverrides: map[string]string{},
+			Name:             "mpv",
+			Executable:       "mpv",
+			Fullscreen:       "--fs",
+			Pip:              `--ontop --no-border --autofit=384x216 --geometry=98%:98%`,
+			Enqueue:          "",
+			NewWindow:        "",
+			NeedsIpc:         true,
+			SupportedSchemes: defaultSupportedSchemas,
+			FlagOverrides:    map[string]string{},
 		},
 	},
 }


### PR DESCRIPTION
## Description

Before I got the following error when no config file existed.

```
2023/05/12 20:52:11 No config file found, using default
2023/05/12 20:52:11 Unsupported schema for player 'mpv': https. Did you forget to add it in the configuration?
```

The commit adds a the default schemas to the default config.

## Type of change

Please delete options which are not relevant.

- [x] Bug fix (**non-breaking** change which fixes an issue)
- [ ] New feature (**non-breaking** change which adds functionality)
- [ ] **Breaking** change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- Code quality:
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
- Tests:
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing unit tests pass locally with my changes
- Other:
  - [ ] I have made corresponding changes to the documentation and/or `README.md`
  - [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)