### PR TITLE
open-in-mpv: respect the player's `executable` config

### DIFF
--- a/cmd/open-in-mpv/main.go
+++ b/cmd/open-in-mpv/main.go
@@ -38,8 +38,8 @@ func main() {
 		log.Println("Error writing to socket, opening new instance")
 	}
 
-	args := opts.GenerateCommand()
-	player := exec.Command(opts.Player, args...)
+	executable, args := opts.GenerateCommand()
+	player := exec.Command(executable, args...)
 	log.Println(player.String())
 	must(player.Start())
 	// must(player.Wait())

--- a/options.go
+++ b/options.go
@@ -149,7 +149,7 @@ func (o Options) overrideFlags() string {
 
 // Builds a CLI command used to invoke the player with the appropriate
 // arguments
-func (o Options) GenerateCommand() []string {
+func (o Options) GenerateCommand() (string, []string) {
 	var ret []string
 
 	playerConfig := GetPlayerConfig(o.Player)
@@ -172,7 +172,7 @@ func (o Options) GenerateCommand() []string {
 
 	ret = append(ret, o.Url.String())
 
-	return ret
+	return playerConfig.Executable, ret
 }
 
 // Builds the IPC command needed to enqueue videos if the player requires it

--- a/options_test.go
+++ b/options_test.go
@@ -31,8 +31,8 @@ func Test_GenerateCommand(t *testing.T) {
 	o.Flags = "--vo=gpu"
 	o.Pip = true
 
-	args := o.GenerateCommand()
-	t.Logf("%s %v", o.Player, args)
+	executable, args := o.GenerateCommand()
+	t.Logf("%s %v", executable, args)
 }
 
 func Test_GenerateIPC(t *testing.T) {
@@ -98,8 +98,8 @@ func Test_Parse(t *testing.T) {
 		t.Fatal("Err should not be nil")
 	}
 
-	args := o.GenerateCommand()
-	t.Logf("%s %v", o.Player, args)
+	executable, args := o.GenerateCommand()
+	t.Logf("%s %v", executable, args)
 }
 
 func Test_sliceContains(t *testing.T) {


### PR DESCRIPTION
## Description

config.yml allows to specify `executable` distinct from player name:
```
players:
  mpv:
    name: mpv
    executable: my-mpv-wrapper
    ...
```

before, the `executable` setting would be ignored:
```
$ open-in-mpv 'mpv:///open?url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ'
2024/02/15 08:27:41 /usr/bin/mpv https://youtu.be/dQw4w9WgXcQ
```

after this patch, it's respected:
```
open-in-mpv 'mpv:///open?url=https%3A%2F%2Fyoutu.be%2FdQw4w9WgXcQ'
2024/02/15 08:27:53 /usr/local/bin/my-mpv-wrapper https://youtu.be/dQw4w9WgXcQ
```

a user might want `executable` to be respected for any number of reasons:
- they want to use open-with-mpv without including mpv on their path
- they're running their browser inside a sandbox that requires them to use a helper program to launch mpv (e.g. flatpak'd web browsers, which have to open apps via the org.freedesktop.Portal API)
- they want to stylize the browser's mpv separately from the system's mpv in a way which is impractical to do with flags alone

## Type of change

Please delete options which are not relevant.

- [x] Bug fix (**non-breaking** change which fixes an issue)

## Checklist

- Code quality:
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
- Tests:
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
- Other:
  - [ ] I have made corresponding changes to the documentation and/or `README.md`
  - [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)