### PR TITLE
Add keyboard shortcut for default action

### DIFF
--- a/extension/Chrome/background.js
+++ b/extension/Chrome/background.js
@@ -1,6 +1,8 @@
 import { getOptions, openInMPV, updateBrowserAction } from "./common.js";
+import { shortcutListener } from "./keyboard.js";
 
 updateBrowserAction();
+shortcutListener();
 
 [["page", "pageUrl"], ["link", "linkUrl"], ["video", "srcUrl"], ["audio", "srcUrl"]].forEach(([item, linkType]) => {
   chrome.contextMenus.create({

--- a/extension/Chrome/keyboard.js
+++ b/extension/Chrome/keyboard.js
@@ -1,0 +1,37 @@
+import { getOptions, getActiveTab, openInMPV } from "./common.js";
+
+function hasCommandListener(listener) {
+  try {
+    return chrome.commands.onCommand.hasListener(listener)
+  } catch (e) {
+    return false
+  }
+}
+
+function handleCommand(command) {
+  if (command === "open-in-mpv-shortcut") {
+    getOptions(options => {
+      getActiveTab((tab) => {
+        if (tab) {
+          openInMPV(tab.id, tab.url, {
+            mode: options.iconActionOption,
+            ...options,
+          })
+        }
+      })
+    })
+  }
+}
+
+export function shortcutListener() {
+  getOptions((options) => {
+    const shortcutsEnabled = options.useShortcut
+    const listenerExists = hasCommandListener(handleCommand)
+
+    if (shortcutsEnabled && !listenerExists) {
+      chrome.commands.onCommand.addListener(handleCommand)
+    } else if (!shortcutsEnabled && listenerExists) {
+      chrome.commands.onCommand.removeListener(handleCommand)
+    }
+  })
+}

--- a/extension/Chrome/manifest.json
+++ b/extension/Chrome/manifest.json
@@ -11,6 +11,13 @@
     "default_icon": "icon.png",
     "default_title": "Open In mpv"
   },
+  "commands": {
+    "open-in-mpv-shortcut": {
+      "suggested_key": {
+        "default": ""
+      }
+    }
+  },
   "permissions": [
     "tabs",
     "activeTab",

--- a/extension/Chrome/options.html
+++ b/extension/Chrome/options.html
@@ -1,66 +1,74 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Options</title>
-  <script src="common.js" type="module"></script>
-  <link rel="stylesheet" href="options.css">
-</head>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Options</title>
+    <script src="common.js" type="module"></script>
+    <link rel="stylesheet" href="options.css">
+  </head>
 
-<body>
-  <div class="container">
-    <h2 class="title">Player options</h2>
-    <div class="option">
-      <label class="option-title"> Select the mpv-based player to use</label>
-      <br>
-      <select name="mpvPlayer">
-        <option value="mpv">mpv</option>
-        <option value="celluloid">Celluloid</option>
-      </select>
-    </div>
-    <div class="option">
-      <label class="option-title"><input type="checkbox" name="useCustomFlags"> Use custom command line flags</label>
-      <div class="option-details" id="customFlagsContainer">
-        <input type="text" name="customFlags">
-        <p> Note: do include hyphens (e.g.<span style="font-family: monospace;">'--fs'</span>)</p>
+  <body>
+    <div class="container">
+      <h2 class="title">Player options</h2>
+      <div class="option">
+        <label class="option-title"> Select the mpv-based player to use</label>
+        <br>
+        <select name="mpvPlayer">
+          <option value="mpv">mpv</option>
+          <option value="celluloid">Celluloid</option>
+        </select>
+      </div>
+      <div class="option">
+        <label class="option-title"><input type="checkbox" name="useCustomFlags"> Use custom command line flags</label>
+        <div class="option-details" id="customFlagsContainer">
+          <input type="text" name="customFlags">
+          <p> Note: do include hyphens (e.g.<span style="font-family: monospace;">'--fs'</span>)</p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="container">
-    <h2 class="title">When clicking on the extension icon</h2>
-    <div class="option">
-      <div class="item">
-        <label><input type="radio" name="iconAction" value="clickOnly"> Open current page in mpv</label>
-      </div>
-      <div class="item">
-        <label><input type="radio" name="iconAction" value="menu"> Show a menu to select action</label>
-      </div>
-    </div>
-  </div>
-  <div class="container">
-    <h2 class="title">Default open action</h2>
-    <div class="option">
-      <div class="option-details">
-        <p>Applies to "Open current page in mpv" and the right click context menu</p>
-      </div>
-      <div class="item">
-        <label><input type="radio" name="iconActionOption" value="direct"> Open directly</label>
-      </div>
-      <div class="item">
-        <label><input type="radio" name="iconActionOption" value="fullScreen"> Enter full screen</label>
-      </div>
-      <div class="item">
-        <label><input type="radio" name="iconActionOption" value="pip"> Enter Picture-in-Picture</label>
-      </div>
-      <div class="item">
-        <label><input type="radio" name="iconActionOption" value="enqueue"> Add to queue</label>
+    <div class="container">
+      <h2 class="title">When clicking on the extension icon</h2>
+      <div class="option">
+        <div class="item">
+          <label><input type="radio" name="iconAction" value="clickOnly"> Open current page in mpv</label>
+        </div>
+        <div class="item">
+          <label><input type="radio" name="iconAction" value="menu"> Show a menu to select action</label>
+        </div>
       </div>
     </div>
-  </div>
-  <script src="options.js" type="module"></script>
-</body>
+    <div class="container">
+      <h2 class="title">Default open action</h2>
+      <div class="option">
+        <div class="option-details">
+          <p>Applies to "Open current page in mpv" and the right click context menu</p>
+        </div>
+        <div class="item">
+          <label><input type="radio" name="iconActionOption" value="direct"> Open directly</label>
+        </div>
+        <div class="item">
+          <label><input type="radio" name="iconActionOption" value="fullScreen"> Enter full screen</label>
+        </div>
+        <div class="item">
+          <label><input type="radio" name="iconActionOption" value="pip"> Enter Picture-in-Picture</label>
+        </div>
+        <div class="item">
+          <label><input type="radio" name="iconActionOption" value="enqueue"> Add to queue</label>
+        </div>
+      </div>
+      <div class="option">
+        <label class="option-title"><input type="checkbox" name="useShortcut"> Use shortcut for default action</label>
+        <div class="option-details" id="">
+          <input type="text" name="shortcutKey">
+          <p>Note: Default browser shortcuts (e.g., <span style="font-family: monospace;">Ctrl+P</span>) cannot be overwritten.<br>
+          Use <a href="about:addons" target="_blank">about:addons</a> (Firefox) or <a href="chrome://extensions/shortcuts" target="_blank">chrome://extensions/shortcuts</a> (Chrome) to set shortcuts more conveniently.</p>
+        </div>
+      </div>
+    </div>
+    <script src="options.js" type="module"></script>
+  </body>
 
 </html>

--- a/extension/Chrome/options.js
+++ b/extension/Chrome/options.js
@@ -1,8 +1,10 @@
 import { restoreOptions, saveOptions, updateBrowserAction } from "./common.js"
+import { shortcutListener } from "./keyboard.js"
 
 const addListener = el => el.addEventListener("change", () => {
-  saveOptions()
-  updateBrowserAction()
+    saveOptions()
+    updateBrowserAction()
+    shortcutListener()
 })
 
 document.addEventListener("DOMContentLoaded", restoreOptions)

--- a/extension/Chrome/popup.js
+++ b/extension/Chrome/popup.js
@@ -1,23 +1,17 @@
-import { openInMPV, getOptions } from "./common.js"
+import { openInMPV, getOptions, getActiveTab } from "./common.js"
 
 Array.prototype.forEach.call(document.getElementsByClassName("menu-item"), item => {
   const mode = item.id.split("-")[1]
   item.addEventListener("click", () => {
     getOptions(options => {
-      chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
-        if (tabs.length === 0)
-          return
-
-        const tab = tabs[0]
-        if (tab.id === chrome.tabs.TAB_ID_NONE)
-          return
-
-        console.log(mode)
-        openInMPV(tab.id, tab.url, {
-          mode,
-          newWindow: mode === "newWindow",
-          ...options,
-        })
+      getActiveTab((tab) => {
+        if (tab) {
+          openInMPV(tab.id, tab.url, {
+            mode,
+            newWindow: mode === "newWindow",
+            ...options,
+          })
+        }
       })
     })
   })

--- a/extension/Firefox/manifest.json
+++ b/extension/Firefox/manifest.json
@@ -18,6 +18,13 @@
     "default_icon": "icon.png",
     "default_title": "Open In mpv"
   },
+  "commands": {
+    "open-in-mpv-shortcut": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+M"
+      }
+    }
+  },
   "permissions": [
     "tabs",
     "activeTab",


### PR DESCRIPTION
## Description
Added the option to set keyboard shortcut through either text in options page (Firefox only) or through browser "manage keyboard shortcuts".

Shortcut changes in the browser will reflect the text box in options and vice-versa, but it recommended to set it through the browser since you have all those default keybinding checks included.
Only Firefox supports changing keyboard shortcuts dynamically (via commands.update() ), due "security concerns" you have to set it through chrome://extensions/shortcuts in Chrome. However, I kept the text box in, since it works on FF.

There _should_ be no breaking change, but I have tested it on Firefox only.


## Type of change
- [x] New feature (**non-breaking** change which adds functionality)
- [x] **Breaking** change (fix or feature that would cause existing functionality to not work as expected)


## Checklist
- Code quality:
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
- Tests:
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing unit tests pass locally with my changes
- Other:
  - [ ] I have made corresponding changes to the documentation and/or `README.md`
  - [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)