### PR TITLE
Handle flags individually, similarly to Picture in Picture mode

### DIFF
--- a/options.go
+++ b/options.go
@@ -105,7 +105,7 @@ func (o *Options) Parse(uri string) error {
 }
 
 // Parses flag overrides and returns the final flags
-func (o Options) overrideFlags() string {
+func (o Options) overrideFlags() []string {
 	var (
 		ret  []string
 		star bool
@@ -113,7 +113,7 @@ func (o Options) overrideFlags() string {
 
 	playerConfig := GetPlayerConfig(o.Player)
 	if playerConfig == nil {
-		return ""
+		return []string{}
 	}
 
 	// Premature look for star override in configuration
@@ -144,7 +144,7 @@ func (o Options) overrideFlags() string {
 		}
 	}
 
-	return strings.Join(ret, " ")
+	return ret
 }
 
 // Builds a CLI command used to invoke the player with the appropriate
@@ -164,9 +164,9 @@ func (o Options) GenerateCommand() (string, []string) {
 
 	if o.Flags != "" {
 		if len(playerConfig.FlagOverrides) == 0 {
-			ret = append(ret, o.Flags)
+			ret = append(ret, strings.Split(o.Flags, " ")...)
 		} else {
-			ret = append(ret, o.overrideFlags())
+			ret = append(ret, o.overrideFlags()...)
 		}
 	}
 

--- a/options_test.go
+++ b/options_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"slices"
 )
 
 var fakePlayer = Player{
@@ -31,23 +32,27 @@ func testUrl(query ...string) string {
 
 func Test_GenerateCommand(t *testing.T) {
 	defaultConfig.Players["fakeplayer"] = fakePlayer
-
 	o := NewOptions()
-	err := o.Parse(testUrl("player=fakeplayer", "flags=--ytdl-format=bestvideo[height<=480]+bestaudio", "pip=1"))
+
+	// The '+' character needs to be escaped twice
+	// to prevent it from decaying to a space
+	err := o.Parse(testUrl("player=fakeplayer", "flags=--ytdl-format=bestvideo[height<=480]%2Bbestaudio --gpu-api=opengl", "pip=1"))
+
 	if err != nil {
 		t.Error(err)
 	}
 
 	executable, args := o.GenerateCommand()
-	t.Logf("%s %v", executable, args)
+	t.Logf("%s %q", executable, args)
 
 	if executable != fakePlayer.Executable {
 		t.Logf("expected the default player to be %s", fakePlayer.Executable)
 		t.Fail()
 	}
-	// We expect 6 args: 1 from o.Flags, 4 from o.Pip and 1 is o.Url
-	if args == nil || len(args) < 6 {
-		t.Logf("expected 6 args, got %d", len(args))
+
+	// We expect 7 args: 2 from o.Flags, 4 from o.Pip and 1 is o.Url
+	if args == nil || len(args) != 7 {
+		t.Logf("expected 7 args, got %d", len(args))
 		t.Fail()
 	}
 }
@@ -71,7 +76,7 @@ func Test_overrideFlags_single(t *testing.T) {
 
 	result := o.overrideFlags()
 
-	if result != "--bar=foo" {
+	if !slices.Equal(result, []string{"--bar=foo"}) {
 		t.Fail()
 		t.Log(result)
 		t.Logf("%#v\n", o)
@@ -90,7 +95,7 @@ func Test_overrideFlags_star(t *testing.T) {
 
 	result := o.overrideFlags()
 
-	if result != "--bar=foo --bar=baz" {
+	if !slices.Equal(result, []string{"--bar=foo", "--bar=baz"}) {
 		t.Fail()
 		t.Log(result)
 		t.Logf("%#v\n", o)


### PR DESCRIPTION
## Description

**Summary**
Changed the way how flags are collected as arguments to prevent a silent fail of mpv.

**Context**
I upgraded mpv to 0.40 which uses the vulkan backend by default. On my system it does not really work, but it is still possible to use opengl if we explicitly specify it as explained [in this issue](https://github.com/mpv-player/mpv/issues/16157#issuecomment-2764570484). Now I thought that adding this flag to open-in-mpv would just work out of the box, but it does not.

**Details**
I investigated a bit to find out what was going on. Previously I used to have this flag with open-in-mpv:
`--ytdl-format=bestvideo[protocol^=m3u8]+bestaudio[protocol^=m3u8]/bestvideo+bestaudio/best`
It has some downsides, but it basically caches videos a lot faster than the default option. Now I added another flag:
`--gpu-api=opengl`, but after that none of the videos I tried to play opened. The log statement seemed okay right before `player.Start` in the main source file.

So it turns out that `o.Flags` is added to args as a single string, unlike `o.Pip` which passes them separately. So instead of this:
`/usr/bin/mpv "--ytdl-format=bestvideo[protocol^=m3u8]+bestaudio[protocol^=m3u8]/bestvideo+bestaudio/best" "--gpu-api=opengl" https://youtu.be/...`
something like this was called:
`/usr/bin/mpv "--ytdl-format=bestvideo[protocol^=m3u8]+bestaudio[protocol^=m3u8]/bestvideo+bestaudio/best --gpu-api=opengl" https://youtu.be/...`
The log statement in `main.go` does not show quotes so both of them look identical but mpv fails as exit code 1 with the latter. Now if you only use a single flag (like me before) this issue is undetected, but 2 or more won't work.

**Dependencies**
I added an import for the `slices` package in the test file of options

## Type of change
- [x] Bug fix (**non-breaking** change which fixes an issue)

## Checklist

- Code quality:
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
- Tests:
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
- Other:
  - [ ] I have made corresponding changes to the documentation and/or `README.md`
  - [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)